### PR TITLE
Add a page to get pushlog from buildid

### DIFF
--- a/buildid_pushlog.html
+++ b/buildid_pushlog.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Build ID -> Pushlog</title>
+<script src="buildid_pushlog.js" type="text/javascript"></script>
+</head>
+<body>
+<input type="text" name="buildID" id="buildID" placeholder="Build ID...">
+<button onclick="javascript: update()">Get pushlog</button>
+<br>
+<span id="pushlogURL"></span>
+</body>
+</html>

--- a/buildid_pushlog.js
+++ b/buildid_pushlog.js
@@ -1,0 +1,44 @@
+function filter(data, buildID) {
+    let lastNode = "";
+    for (var info of data.builds) {
+        if (!lastNode && (info.buildid == buildID)) {
+            lastNode = info.node;
+        } else if (lastNode && (info.buildid != buildID)) {
+            return {"last": lastNode,
+                    "prev": info.node};
+        }
+    }
+    return null;
+}
+
+function fromBuildIDToPushlog(buildID) {
+    buildID = buildID.trim();
+    return fetch('https://hg.mozilla.org/mozilla-central/json-firefoxreleases')
+                            .then(response => response.json())
+                            .then(json_fxrel => {
+                                let revs = filter(json_fxrel, buildID);
+                                if (revs !== null) {
+                                    let url1 = "https://hg.mozilla.org/mozilla-central/pushloghtml?fromchange=";
+                                    let url2 = "&tochange=";
+                                    return url1 + revs.prev + url2 + revs.last;
+                                } else {
+                                    return "";
+                                }
+                            })
+                            .catch(error => {
+                                console.log(error);
+                            });
+} 
+
+function update() {
+    let buildID = document.getElementById("buildID").value;
+    fromBuildIDToPushlog(buildID)
+        .then(url => {
+            let span = document.getElementById("pushlogURL");
+            if (url) {
+                span.innerHTML = "<a href=\"" + url + "\">" + url + "</a>";
+            } else {
+                span.textContent = "Invalid build-id";
+            }
+        });
+}


### PR DESCRIPTION
Since we've 2 nightly builds per day, this web page would make easier to get the pushlog for a particular build-id.