### PR TITLE
In common landings, don't retrieve bug data but use a link to Bugzilla

### DIFF
--- a/common_landings.js
+++ b/common_landings.js
@@ -174,7 +174,7 @@ onLoad
 
       let a = document.createElement('a');
       a.textContent = 'List of common landings on Bugzilla';
-      a.href = 'https://bugzilla.mozilla.org/buglist.cgi?quicksearch=';
+      a.href = 'https://bugzilla.mozilla.org/buglist.cgi?bug_id=';
       a.id = 'buglist';
       results.appendChild(a);	  
 

--- a/common_landings.js
+++ b/common_landings.js
@@ -172,21 +172,16 @@ onLoad
         return;
       }
 
-      let ul = document.createElement('ul');
-      for (let bug of bugs) {
-        fetch('https://bugzilla.mozilla.org/rest/bug/' + bug + '?include_fields=summary')
-        .then(response => response.json())
-        .then(bugData => {
-          let li = document.createElement('li');
-          let a = document.createElement('a');
-          a.textContent = bug + ' - ' + (('bugs' in bugData) ? bugData['bugs'][0]['summary'] : 'Inaccessible');
-          a.href = 'https://bugzilla.mozilla.org/show_bug.cgi?id=' + bug;
-          li.appendChild(a);
-          ul.appendChild(li);
-        });
-      }
+      let a = document.createElement('a');
+      a.textContent = 'List of common landings on Bugzilla';
+      a.href = 'https://bugzilla.mozilla.org/buglist.cgi?quicksearch=';
+      a.id = 'buglist';
+      results.appendChild(a);	  
 
-      results.appendChild(ul);
+      for (let bug of bugs) {
+        let a = document.getElementById('buglist');
+	    a.href += bug +","; 
+      }
     });
   };
 });


### PR DESCRIPTION
proposing this change because i think the current polling of the api might contribute to temporary bans on bugzilla (https://bugzilla.mozilla.org/show_bug.cgi?id=1482644) after moderate usage of this tool.

as an added benefit, having the result directly available as a buglist on bugzilla allows you to sort/filter bugs by components, assignees etc.