### PR TITLE
Taskcluster v102 no longer supports normal priority - change to lowest

### DIFF
--- a/taskcluster-hook.json
+++ b/taskcluster-hook.json
@@ -38,7 +38,7 @@
       "image": "python:3.12",
       "maxRunTime": 7200
     },
-    "priority": "normal",
+    "priority": "lowest",
     "provisionerId": "proj-relman",
     "retries": 5,
     "routes": [


### PR DESCRIPTION
Prior to Taskcluster v102.0.1, task priority `normal` was internally [mapped](https://github.com/taskcluster/taskcluster/blob/05bfba092ae07bff31b232a1c502ee23ba08a46a/services/queue/src/api.js#L687) to `lowest`.

This sets it explicitly, since `normal` priority was removed in https://github.com/taskcluster/taskcluster/pull/8865 which was released in [Taskcluster v102.0.1](https://github.com/taskcluster/taskcluster/releases/tag/v102.0.1).